### PR TITLE
added storage folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ Thumbs.db
 *.sql
 *.sqlite
 .env.dev
+
+# Cache #
+###################
+/storage


### PR DESCRIPTION
Storage folder generates cache for views file. We do not need these cache files in git repo. That's why added in .gitignore list